### PR TITLE
Hotfix/eks cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -325,6 +325,7 @@ module external_secrets {
   source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-secrets?ref=hotfix/eks_cluster"
   argocd = module.argocd.state  
   cluster_name = var.cluster_name
+  cluster_oidc_url = module.kubernetes.cluster_oidc_url
 
   // Set to false create and attach role to external_secrets service account that has no policies attached to it. This role will then be used to assume other role with fine granular access. This is the recommended approach
   // Set to true to with the external_secrets service account full access to all secrets prefixed with the cluster name. This is more convenient but less secure.

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 
 module network {
   count = var.vpc_id == null ? 1 : 0
-  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/network?ref=hotfix/eks_cluster"
+  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/network?ref=v1.0.12"
   availability_zones = var.availability_zones
   environment        = var.environment
   project            = var.project
@@ -44,7 +44,7 @@ EOF
 
 // Kubernetes Cluster
 module kubernetes {
-  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubernetes?ref=hotfix/eks_cluster"
+  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubernetes?ref=v1.0.12"
   availability_zones = var.availability_zones
   environment        = var.environment
   project            = var.project
@@ -91,7 +91,7 @@ module acm {
 
 // Create Cognito User Pool
 module cognito {
-  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/user-pool?ref=hotfix/eks_cluster"
+  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/user-pool?ref=v1.0.12"
   domain       = var.domain //TODO make "auth" parameterisable? Currently it is hardcode in the "cognito" module
   zone_id      = module.external_dns.zone_id
   cluster_name = module.kubernetes.cluster_name
@@ -138,7 +138,7 @@ resource aws_cognito_user_pool_client argocd {
 
 // Create Cognito Users
 module cognito_users {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/users?ref=hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/users?ref=v1.0.12"
   cloudformation_stack_name = "${var.cluster_name}-cognito-users"
   pool_id  = module.cognito.pool_id
   user_groups = ["default"] //TODO
@@ -149,7 +149,7 @@ module cognito_users {
 
 // Create RDS instance
 module "rds" {
-  source  = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/rds?ref=hotfix/eks_cluster"
+  source  = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/rds?ref=v1.0.12"
 
   environment  = var.environment
   project      = var.project
@@ -181,7 +181,7 @@ module "rds" {
 
 // Create S3 bucket
 module "s3" {
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/storage/s3?ref=hotfix/eks_cluster"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/storage/s3?ref=v1.0.12"
   module_depends_on = []
   s3_bucket_name    = "${var.aws_account}-${var.cluster_name}-kubeflow"
   cluster_name      = var.cluster_name
@@ -242,7 +242,7 @@ resource "kubernetes_config_map" "knative_network_config_map" {
 
 // ArgoCD
 module argocd {
-  source                    = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cicd/argo-cd?ref=hotfix/eks_cluster"
+  source                    = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cicd/argo-cd?ref=v1.0.12"
   module_depends_on         = [module.kubernetes]
   sync_branch               = var.argocd_branch
   sync_path_prefix          = var.argocd_path_prefix
@@ -280,7 +280,7 @@ module argocd {
 
 // Create YAML specs for MLFLow
 module mlflow {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/mlflow?ref=hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/mlflow?ref=v1.0.12"
   argocd = module.argocd.state
   rds_username = module.rds.this_db_instance_username
   rds_password = module.rds.this_db_instance_password  
@@ -302,27 +302,27 @@ module mlflow {
 
 // Create YAML specs for Kubeflow Profiles
 module profiles {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-profiles?ref=hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-profiles?ref=v1.0.12"
   argocd = module.argocd.state
   profiles = var.kubeflow_profiles
 }
 
 // Create YAML specs for kube2iam
 module kube2iam {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/kube2iam?ref=hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/kube2iam?ref=v1.0.12"
   argocd = module.argocd.state
   base_role_arn = var.kube2iam_role_arn
 }
 
 // Create YAML specs for KFServing
 module kfserving {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kfserving/0-3-0/?ref=hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kfserving/0-3-0/?ref=v1.0.12"
   argocd = module.argocd.state
 }
 
 // Create YAML specs for External-Secrets
 module external_secrets {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-secrets?ref=hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-secrets?ref=v1.0.12"
   argocd = module.argocd.state  
   cluster_name = var.cluster_name
   cluster_oidc_url = module.kubernetes.cluster_oidc_url
@@ -335,7 +335,7 @@ module external_secrets {
 
 // Create YAML specs for Kubeflow Operator and KFDef
 module kubeflow {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-operator?ref=hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-operator?ref=v1.0.12"
   rds_username = module.rds.this_db_instance_username
   rds_password = module.rds.this_db_instance_password  
   rds_host = module.rds.this_db_instance_address
@@ -461,7 +461,7 @@ EOT
 
 // Create YAML specs for Cluster Autoscaler
 module cluster_autoscaler {
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cluster-autoscaler?ref=hotfix/eks_cluster"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cluster-autoscaler?ref=v1.0.12"
   image_tag         = "v1.15.7"
   cluster_name      = module.kubernetes.cluster_name
   module_depends_on = [module.kubernetes]
@@ -472,7 +472,7 @@ module cluster_autoscaler {
 // Create YAML specs for Certificate Manager
 module cert_manager {
   module_depends_on = [module.kubernetes]
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cert-manager?ref=hotfix/eks_cluster"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cert-manager?ref=v1.0.12"
   cluster_name      = module.kubernetes.cluster_name
   domains           = [var.domain]
   vpc_id            = local.vpc_id
@@ -487,7 +487,7 @@ module cert_manager {
 // Create YAML specs for ALB Ingress
 module alb_ingress {
   module_depends_on = [module.kubernetes]
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/ingress/aws-alb?ref=hotfix/eks_cluster"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/ingress/aws-alb?ref=v1.0.12"
   cluster_name      = module.kubernetes.cluster_name
   domains           = [var.domain]
   vpc_id            = local.vpc_id
@@ -497,7 +497,7 @@ module alb_ingress {
 
 // Create YAML specs for External DNS
 module external_dns {
-  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-dns?ref=hotfix/eks_cluster"
+  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-dns?ref=v1.0.12"
   cluster_name = module.kubernetes.cluster_name
   vpc_id       = local.vpc_id
   aws_private  = var.aws_private

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 
 module network {
   count = var.vpc_id == null ? 1 : 0
-  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/network?ref=v1.0.11"
+  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/network?ref=/hotfix/eks_cluster"
   availability_zones = var.availability_zones
   environment        = var.environment
   project            = var.project
@@ -44,7 +44,7 @@ EOF
 
 // Kubernetes Cluster
 module kubernetes {
-  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubernetes?ref=v1.0.11"
+  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubernetes?ref=/hotfix/eks_cluster"
   availability_zones = var.availability_zones
   environment        = var.environment
   project            = var.project
@@ -91,7 +91,7 @@ module acm {
 
 // Create Cognito User Pool
 module cognito {
-  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/user-pool?ref=v1.0.11"
+  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/user-pool?ref=/hotfix/eks_cluster"
   domain       = var.domain //TODO make "auth" parameterisable? Currently it is hardcode in the "cognito" module
   zone_id      = module.external_dns.zone_id
   cluster_name = module.kubernetes.cluster_name
@@ -138,7 +138,7 @@ resource aws_cognito_user_pool_client argocd {
 
 // Create Cognito Users
 module cognito_users {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/users?ref=v1.0.11"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/users?ref=/hotfix/eks_cluster"
   cloudformation_stack_name = "${var.cluster_name}-cognito-users"
   pool_id  = module.cognito.pool_id
   user_groups = ["default"] //TODO
@@ -149,7 +149,7 @@ module cognito_users {
 
 // Create RDS instance
 module "rds" {
-  source  = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/rds?ref=v1.0.11"
+  source  = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/rds?ref=/hotfix/eks_cluster"
 
   environment  = var.environment
   project      = var.project
@@ -181,7 +181,7 @@ module "rds" {
 
 // Create S3 bucket
 module "s3" {
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/storage/s3?ref=v1.0.11"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/storage/s3?ref=/hotfix/eks_cluster"
   module_depends_on = []
   s3_bucket_name    = "${var.aws_account}-${var.cluster_name}-kubeflow"
   cluster_name      = var.cluster_name
@@ -242,7 +242,7 @@ resource "kubernetes_config_map" "knative_network_config_map" {
 
 // ArgoCD
 module argocd {
-  source                    = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cicd/argo-cd?ref=v1.0.11"
+  source                    = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cicd/argo-cd?ref=/hotfix/eks_cluster"
   module_depends_on         = [module.kubernetes]
   sync_branch               = var.argocd_branch
   sync_path_prefix          = var.argocd_path_prefix
@@ -280,7 +280,7 @@ module argocd {
 
 // Create YAML specs for MLFLow
 module mlflow {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/mlflow?ref=v1.0.11"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/mlflow?ref=/hotfix/eks_cluster"
   argocd = module.argocd.state
   rds_username = module.rds.this_db_instance_username
   rds_password = module.rds.this_db_instance_password  
@@ -302,27 +302,27 @@ module mlflow {
 
 // Create YAML specs for Kubeflow Profiles
 module profiles {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-profiles?ref=v1.0.11"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-profiles?ref=/hotfix/eks_cluster"
   argocd = module.argocd.state
   profiles = var.kubeflow_profiles
 }
 
 // Create YAML specs for kube2iam
 module kube2iam {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/kube2iam?ref=v1.0.11"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/kube2iam?ref=/hotfix/eks_cluster"
   argocd = module.argocd.state
   base_role_arn = var.kube2iam_role_arn
 }
 
 // Create YAML specs for KFServing
 module kfserving {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kfserving/0-3-0/?ref=v1.0.11"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kfserving/0-3-0/?ref=/hotfix/eks_cluster"
   argocd = module.argocd.state
 }
 
 // Create YAML specs for External-Secrets
 module external_secrets {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-secrets?ref=v1.0.11"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-secrets?ref=/hotfix/eks_cluster"
   argocd = module.argocd.state  
   cluster_name = var.cluster_name
 
@@ -334,7 +334,7 @@ module external_secrets {
 
 // Create YAML specs for Kubeflow Operator and KFDef
 module kubeflow {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-operator?ref=v1.0.11"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-operator?ref=/hotfix/eks_cluster"
   rds_username = module.rds.this_db_instance_username
   rds_password = module.rds.this_db_instance_password  
   rds_host = module.rds.this_db_instance_address
@@ -460,7 +460,7 @@ EOT
 
 // Create YAML specs for Cluster Autoscaler
 module cluster_autoscaler {
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cluster-autoscaler?ref=v1.0.11"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cluster-autoscaler?ref=/hotfix/eks_cluster"
   image_tag         = "v1.15.7"
   cluster_name      = module.kubernetes.cluster_name
   module_depends_on = [module.kubernetes]
@@ -471,7 +471,7 @@ module cluster_autoscaler {
 // Create YAML specs for Certificate Manager
 module cert_manager {
   module_depends_on = [module.kubernetes]
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cert-manager?ref=v1.0.11"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cert-manager?ref=/hotfix/eks_cluster"
   cluster_name      = module.kubernetes.cluster_name
   domains           = [var.domain]
   vpc_id            = local.vpc_id
@@ -486,7 +486,7 @@ module cert_manager {
 // Create YAML specs for ALB Ingress
 module alb_ingress {
   module_depends_on = [module.kubernetes]
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/ingress/aws-alb?ref=v1.0.11"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/ingress/aws-alb?ref=/hotfix/eks_cluster"
   cluster_name      = module.kubernetes.cluster_name
   domains           = [var.domain]
   vpc_id            = local.vpc_id
@@ -496,7 +496,7 @@ module alb_ingress {
 
 // Create YAML specs for External DNS
 module external_dns {
-  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-dns?ref=v1.0.11"
+  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-dns?ref=/hotfix/eks_cluster"
   cluster_name = module.kubernetes.cluster_name
   vpc_id       = local.vpc_id
   aws_private  = var.aws_private

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 
 module network {
   count = var.vpc_id == null ? 1 : 0
-  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/network?ref=/hotfix/eks_cluster"
+  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/network?ref=hotfix/eks_cluster"
   availability_zones = var.availability_zones
   environment        = var.environment
   project            = var.project
@@ -44,7 +44,7 @@ EOF
 
 // Kubernetes Cluster
 module kubernetes {
-  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubernetes?ref=/hotfix/eks_cluster"
+  source             = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubernetes?ref=hotfix/eks_cluster"
   availability_zones = var.availability_zones
   environment        = var.environment
   project            = var.project
@@ -91,7 +91,7 @@ module acm {
 
 // Create Cognito User Pool
 module cognito {
-  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/user-pool?ref=/hotfix/eks_cluster"
+  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/user-pool?ref=hotfix/eks_cluster"
   domain       = var.domain //TODO make "auth" parameterisable? Currently it is hardcode in the "cognito" module
   zone_id      = module.external_dns.zone_id
   cluster_name = module.kubernetes.cluster_name
@@ -138,7 +138,7 @@ resource aws_cognito_user_pool_client argocd {
 
 // Create Cognito Users
 module cognito_users {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/users?ref=/hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cognito/users?ref=hotfix/eks_cluster"
   cloudformation_stack_name = "${var.cluster_name}-cognito-users"
   pool_id  = module.cognito.pool_id
   user_groups = ["default"] //TODO
@@ -149,7 +149,7 @@ module cognito_users {
 
 // Create RDS instance
 module "rds" {
-  source  = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/rds?ref=/hotfix/eks_cluster"
+  source  = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/rds?ref=hotfix/eks_cluster"
 
   environment  = var.environment
   project      = var.project
@@ -181,7 +181,7 @@ module "rds" {
 
 // Create S3 bucket
 module "s3" {
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/storage/s3?ref=/hotfix/eks_cluster"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/storage/s3?ref=hotfix/eks_cluster"
   module_depends_on = []
   s3_bucket_name    = "${var.aws_account}-${var.cluster_name}-kubeflow"
   cluster_name      = var.cluster_name
@@ -242,7 +242,7 @@ resource "kubernetes_config_map" "knative_network_config_map" {
 
 // ArgoCD
 module argocd {
-  source                    = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cicd/argo-cd?ref=/hotfix/eks_cluster"
+  source                    = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/cicd/argo-cd?ref=hotfix/eks_cluster"
   module_depends_on         = [module.kubernetes]
   sync_branch               = var.argocd_branch
   sync_path_prefix          = var.argocd_path_prefix
@@ -280,7 +280,7 @@ module argocd {
 
 // Create YAML specs for MLFLow
 module mlflow {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/mlflow?ref=/hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/mlflow?ref=hotfix/eks_cluster"
   argocd = module.argocd.state
   rds_username = module.rds.this_db_instance_username
   rds_password = module.rds.this_db_instance_password  
@@ -302,27 +302,27 @@ module mlflow {
 
 // Create YAML specs for Kubeflow Profiles
 module profiles {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-profiles?ref=/hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-profiles?ref=hotfix/eks_cluster"
   argocd = module.argocd.state
   profiles = var.kubeflow_profiles
 }
 
 // Create YAML specs for kube2iam
 module kube2iam {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/kube2iam?ref=/hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/kube2iam?ref=hotfix/eks_cluster"
   argocd = module.argocd.state
   base_role_arn = var.kube2iam_role_arn
 }
 
 // Create YAML specs for KFServing
 module kfserving {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kfserving/0-3-0/?ref=/hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kfserving/0-3-0/?ref=hotfix/eks_cluster"
   argocd = module.argocd.state
 }
 
 // Create YAML specs for External-Secrets
 module external_secrets {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-secrets?ref=/hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-secrets?ref=hotfix/eks_cluster"
   argocd = module.argocd.state  
   cluster_name = var.cluster_name
 
@@ -334,7 +334,7 @@ module external_secrets {
 
 // Create YAML specs for Kubeflow Operator and KFDef
 module kubeflow {
-  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-operator?ref=/hotfix/eks_cluster"
+  source = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/kubeflow-operator?ref=hotfix/eks_cluster"
   rds_username = module.rds.this_db_instance_username
   rds_password = module.rds.this_db_instance_password  
   rds_host = module.rds.this_db_instance_address
@@ -460,7 +460,7 @@ EOT
 
 // Create YAML specs for Cluster Autoscaler
 module cluster_autoscaler {
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cluster-autoscaler?ref=/hotfix/eks_cluster"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cluster-autoscaler?ref=hotfix/eks_cluster"
   image_tag         = "v1.15.7"
   cluster_name      = module.kubernetes.cluster_name
   module_depends_on = [module.kubernetes]
@@ -471,7 +471,7 @@ module cluster_autoscaler {
 // Create YAML specs for Certificate Manager
 module cert_manager {
   module_depends_on = [module.kubernetes]
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cert-manager?ref=/hotfix/eks_cluster"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/cert-manager?ref=hotfix/eks_cluster"
   cluster_name      = module.kubernetes.cluster_name
   domains           = [var.domain]
   vpc_id            = local.vpc_id
@@ -486,7 +486,7 @@ module cert_manager {
 // Create YAML specs for ALB Ingress
 module alb_ingress {
   module_depends_on = [module.kubernetes]
-  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/ingress/aws-alb?ref=/hotfix/eks_cluster"
+  source            = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/ingress/aws-alb?ref=hotfix/eks_cluster"
   cluster_name      = module.kubernetes.cluster_name
   domains           = [var.domain]
   vpc_id            = local.vpc_id
@@ -496,7 +496,7 @@ module alb_ingress {
 
 // Create YAML specs for External DNS
 module external_dns {
-  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-dns?ref=/hotfix/eks_cluster"
+  source       = "git::https://github.com/at-gmbh/swiss-army-kube.git//modules/system/external-dns?ref=hotfix/eks_cluster"
   cluster_name = module.kubernetes.cluster_name
   vpc_id       = local.vpc_id
   aws_private  = var.aws_private


### PR DESCRIPTION
In version v1.0.12 of at swiss-army-kube (https://github.com/at-gmbh/swiss-army-kube/releases/tag/v1.0.12), the cluster name and the oidc issuer url have to be passed into the external-secrets as variables.

The changes in this PR make this repo compliant with v1.0.12 of swiss-army-kube